### PR TITLE
Add option to match container to ip via given docker network.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ script, or set via docker environment variables.
 | ROLE\_MAPPING\_FILE | Path String | | A json file that has a dict mapping of IP addresses to role names. Can be used if docker networking has been disabled and you are managing IP addressing for containers through another process. |
 | ROLE\_REVERSE\_LOOKUP | Boolean | False | Enable performing a reverse lookup of incoming IP addresses to match containers by hostname. Useful if you've disabled networking in docker, but set hostnames for containers in /etc/hosts or DNS. |
 | HOSTNAME\_MATCH\_REGEX | Regex String | `^.*$` | Limit reverse lookup container matching to hostnames that match the specified pattern. |
+| DOCKER\_NETWORK | String | | Name of docker network used by containers to reach metadataproxy.  Used for matching ip addresses to containers. |
 
 #### Default Roles
 

--- a/metadataproxy/settings.py
+++ b/metadataproxy/settings.py
@@ -111,3 +111,6 @@ MESOS_STATE_LOOKUP = bool_env('MESOS_STATE_LOOKUP', False)
 MESOS_STATE_URL = str_env('MESOS_STATE_URL', 'http://localhost:5051/state')
 # Timeout to use when calling the mesos state endpoint
 MESOS_STATE_TIMEOUT = int_env('MESOS_STATE_TIMEOUT', 2)
+# Name of docker network that containers use to reach metadataproxy.
+# Used for matching containers to ip address.
+DOCKER_NETWORK = str_env('DOCKER_NETWORK')


### PR DESCRIPTION
## Problem

Consider a swarm node where `my-swarm-container` and `metadataproxy-container` run.  `metadataproxy-container` is not part of the swarm and is run in the following way.

```
$ docker run -d --net=host -v /var/run/docker.sock:/var/run/docker.sock --name metadataproxy-container metadataproxy-image
$ iptables PREROUTING -d 169.254.169.254/32 -i docker_gwbridge -p tcp -m tcp --dport 80 -j DNAT --to-destination $LOCAL_IPV4:8000
```

The problem is that `my-swarm-container` will ask `metadataproxy-container` for credentials and `metadataproxy-container` will respond with status 404 and will output the following in its logs.

```
{"asctime": "2020-04-09 01:10:05,003", "name": "metadataproxy.roles", "levelname": "ERROR", "message": "No container found for ip 172.18.0.7"}
{"asctime": "2020-04-09 01:10:05,003", "name": "metadataproxy.routes.proxy", "levelname": "ERROR", "message": "Role name not found; returning 404."}
```

The reason is that swarm bridge network `docker_gwbridge` is not reported in the output of `docker inspect my-swarm-container` (see https://github.com/moby/libnetwork/issues/1082).  When metadataproxy tries to match request ip to its container, it looks at the ip of each container in the node and finds no match.

A solution to the problem is to match the ip to its container by looking at the list of containers for network `docker_gwbridge`. This PR implements the lookup.

## Changes

For the purpose of matching request ip to its swarm container, add the option to look for the container in the inspect JSON for swarm bridge network.  Changes are the following.

1. Add environment variable `DOCKER_NETWORK`.  The variable gives the name of the docker network to use to match request ip to its container.
2. Method `roles.find_container_by_network(ip, network_name)` that returns either the container corresponding to `ip` or `None`.
3. Apply previous method to container lookup in `roles.find_container(ip)`.

## Tests
Tested in swarm node by running `my-swarm-container-that-asks-for-a-role` and running `metadataproxy-container` in the following way:
```
$ docker run -d --net=host --env DOCKER_NETWORK=docker_gwbridge -v /var/run/docker.sock:/var/run/docker.sock --name metadataproxy-container metadataproxy-image
$ iptables PREROUTING -d 169.254.169.254/32 -i docker_gwbridge -p tcp -m tcp --dport 80 -j DNAT --to-destination $LOCAL_IPV4:8000
```