### PR TITLE
Exec gunicorn to catch signals.

### DIFF
--- a/run-server.sh
+++ b/run-server.sh
@@ -24,4 +24,4 @@ fi
 
 export PYTHONUNBUFFERED="true"
 
-/usr/local/bin/gunicorn metadataproxy:app -c $GUNICORN_CONFIG --log-level $LEVEL --workers=$WORKERS -k gevent -b $HOST:$PORT --access-logfile - --error-logfile - --log-file -
+exec /usr/local/bin/gunicorn metadataproxy:app -c $GUNICORN_CONFIG --log-level $LEVEL --workers=$WORKERS -k gevent -b $HOST:$PORT --access-logfile - --error-logfile - --log-file -


### PR DESCRIPTION
The container is not catching signals and it takes a loooooong time to stop.  This fixes that.

Compare the logs:

1. Without this PR.
```
Apr 16 22:15:13 docker.ip-10-13-5-34.ec2.internal systemd[1]: Stopping metadataproxy...                                                                                                      
Apr 16 22:15:23 docker.ip-10-13-5-34.ec2.internal docker[12719]: mdproxy.service                                                                                                                          
Apr 16 22:15:23 docker.ip-10-13-5-34.ec2.internal systemd[1]: mdproxy.service: Main process exited, code=exited, status=137/n/a 
```
2. With this PR.
```
Apr 16 22:46:04 docker.ip-10-13-5-34.ec2.internal systemd[1]: Stopping metadataproxy...
Apr 16 22:46:04 docker.ip-10-13-5-34.ec2.internal docker[23551]: {"asctime": "2020-04-16 22:46:04,781", "name": "gunicorn.error", "levelname": "INFO", "message": "Handling signal: term"}
Apr 16 22:46:05 docker.ip-10-13-5-34.ec2.internal docker[23551]: {"asctime": "2020-04-16 22:46:05,174", "name": "gunicorn.error", "levelname": "INFO", "message": "Worker exiting (pid: 10)"}
Apr 16 22:46:05 docker.ip-10-13-5-34.ec2.internal docker[23551]: {"asctime": "2020-04-16 22:46:05,282", "name": "gunicorn.error", "levelname": "INFO", "message": "Shutting down: Master"}
Apr 16 22:46:05 docker.ip-10-13-5-34.ec2.internal docker[23892]: mdproxy.service
```